### PR TITLE
restart mysql immediately when my.cnf updated

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -52,7 +52,7 @@ action :create do
     end
 
     provider Chef::Provider::Service::Upstart if platform?("ubuntu") && node["platform_version"].to_f >= 13.10
-    subscribes :restart, 'template[my.cnf]'
+    subscribes :restart, 'template[my.cnf]', :immediately
     action     [:enable, :start]
     not_if     { new_resource.service_name.empty? }
   end


### PR DESCRIPTION
When I write recipe as below sequence
1. install mysql-server with include mysqld cookbook
2. create database with database cookbook

When create database. my.cnf was updated but configuration was not reload. so that created database was not affected update configuration(eg. character-set-server=utf8 option). : restart action executed after create database 

so :immediately option needed in service definition.
