### PR TITLE
This cookbook had some incompatibilities when using it with Ubuntu 16.04

### DIFF
--- a/attributes/defaults.rb
+++ b/attributes/defaults.rb
@@ -67,16 +67,24 @@ else
   end
 end
 
+if node["platform"] == "ubuntu" and node["platform_version"].to_f >= 16.04
+  default["mysqld"]["my.cnf"]["mysqld"]["key_buffer_size"] = "16M"
+  default["mysqld"]["my.cnf"]["mysqld"]["innodb_additional_mem_pool_size"] = false
+  default["mysqld"]["my.cnf"]["mysqld"]["myisam_recover_options"] = "BACKUP"
+else
+  default["mysqld"]["my.cnf"]["mysqld"]["key_buffer"] = "16M"
+  default["mysqld"]["my.cnf"]["mysqld"]["innodb_additional_mem_pool_size"] = "16M" 
+  default["mysqld"]["my.cnf"]["mysqld"]["myisam_recover"] = "BACKUP"
+end
+
 default['mysqld']['my.cnf']['mysqld']['bind-address'] = '127.0.0.1'
 default['mysqld']['my.cnf']['mysqld']['port'] = 3306
 default['mysqld']['my.cnf']['mysqld']['user'] = 'mysql'
 default['mysqld']['my.cnf']['mysqld']['symbolic-links'] = 0
 default['mysqld']['my.cnf']['mysqld']['skip-external-locking'] = true
-default['mysqld']['my.cnf']['mysqld']['key_buffer'] = '16M'
 default['mysqld']['my.cnf']['mysqld']['max_allowed_packet'] = '16M'
 default['mysqld']['my.cnf']['mysqld']['thread_stack'] = '192K'
 default['mysqld']['my.cnf']['mysqld']['thread_cache_size'] = 8
-default['mysqld']['my.cnf']['mysqld']['myisam-recover'] = 'BACKUP'
 default['mysqld']['my.cnf']['mysqld']['query_cache_limit'] = '1M'
 default['mysqld']['my.cnf']['mysqld']['query_cache_size'] = '16M'
 default['mysqld']['my.cnf']['mysqld']['expire_logs_days'] = 10
@@ -84,7 +92,6 @@ default['mysqld']['my.cnf']['mysqld']['max_binlog_size'] = '100M'
 default['mysqld']['my.cnf']['mysqld']['innodb_file_per_table'] = 1
 default['mysqld']['my.cnf']['mysqld']['innodb_thread_concurrency'] = 0
 default['mysqld']['my.cnf']['mysqld']['innodb_flush_log_at_trx_commit'] = 1
-default['mysqld']['my.cnf']['mysqld']['innodb_additional_mem_pool_size'] = '16M'
 default['mysqld']['my.cnf']['mysqld']['innodb_log_buffer_size'] = '4M'
 
 default['mysqld']['my.cnf']['mysqldump']['quick'] = true

--- a/spec/recipes/Berksfile
+++ b/spec/recipes/Berksfile
@@ -1,0 +1,4 @@
+source "https://supermarket.chef.io"
+
+cookbook "apt", "~> 4.0.2"
+cookbook "mysqld", :path => "../../"

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -1,31 +1,55 @@
 require_relative '../spec_helper'
 
+require "chefspec/berkshelf"
+
 describe 'mysqld::default' do
   let(:rhel) do
-    ChefSpec::Runner.new(platform: 'centos', version: '6.5').converge(described_recipe)
+    ChefSpec::SoloRunner.new(platform: 'centos', version: '6.5').converge(described_recipe)
   end
 
   let(:debian) do
-    ChefSpec::Runner.new(platform: 'ubuntu', version: '12.04').converge(described_recipe)
+    ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '12.04').converge(described_recipe)
+  end
+
+  let(:ubuntu_1604) do
+    ChefSpec::SoloRunner.new(platform: "ubuntu", version: "16.04").converge(described_recipe)
   end
 
   it 'should use the correct mysql server package' do
-    expect(rhel.node['mysqld']['packages']).to eq(%w(mysql-server))
-    expect(debian.node['mysqld']['packages']).to eq(%w(mysql-server))
+    expect(rhel.node['mysqld']['mysql_packages']).to eq(%w(mysql-server))
+    expect(debian.node['mysqld']['mysql_packages']).to eq(%w(mysql-server))
+    expect(ubuntu_1604.node["mysqld"]["mysql_packages"]).to eq(%w(mysql-server))
   end
 
   it 'should use distribution specific my.cnf path' do
     expect(rhel.node['mysqld']['my.cnf_path']).to eq('/etc/my.cnf')
     expect(debian.node['mysqld']['my.cnf_path']).to eq('/etc/mysql/my.cnf')
+    expect(ubuntu_1604.node["mysqld"]["my.cnf_path"]).to eq("/etc/mysql/my.cnf")
   end
 
   it 'should use distribution specific service name' do
     expect(rhel.node['mysqld']['service_name']).to eq('mysqld')
     expect(debian.node['mysqld']['service_name']).to eq('mysql')
+    expect(ubuntu_1604.node["mysqld"]["service_name"]).to eq("mysql")
   end
 
   it 'should run mysqld_default provider' do
     expect(rhel).to create_mysqld
     expect(debian).to create_mysqld
+    expect(ubuntu_1604).to create_mysqld
+  end
+
+  it "should use distribution and version specific attributes" do
+    expect(ubuntu_1604.node["mysqld"]["my.cnf"]["mysqld"]["key_buffer_size"]).to eq("16M")
+    expect(debian.node["mysqld"]["my.cnf"]["mysqld"]["key_buffer"]).to eq("16M")
+    expect(rhel.node["mysqld"]["my.cnf"]["mysqld"]["key_buffer"]).to eq("16M")
+   
+    expect(ubuntu_1604.node["mysqld"]["my.cnf"]["mysqld"]["myisam_recover_options"]).to eq("BACKUP")
+    expect(debian.node["mysqld"]["my.cnf"]["mysqld"]["myisam_recover"]).to eq("BACKUP")
+    expect(rhel.node["mysqld"]["my.cnf"]["mysqld"]["myisam_recover"]).to eq("BACKUP") 
+
+    expect(ubuntu_1604.node["mysqld"]["my.cnf"]["mysqld"]["innodb_additional_mem_pool_size"]).to eq(false) 
+    expect(debian.node["mysqld"]["my.cnf"]["mysqld"]["innodb_additional_mem_pool_size"]).to eq("16M")
+    expect(rhel.node["mysqld"]["my.cnf"]["mysqld"]["innodb_additional_mem_pool_size"]).to eq("16M")
   end
 end


### PR DESCRIPTION
Hi,
I found a few incompatibilities when trying to use this cookbook with Ubuntu-16.04 so fixed them and it's working out for me.

Changes that I made:
According to [MySQL Documentation](http://dev.mysql.com/doc/refman/5.7/en/downgrading-to-previous-series.html) the column password of table mysql.user was replaced with column authentication string (MySQL 5.7). Ubuntu-16.04 only has mysql-server-5.7, so I checked for the Ubuntu version. I wasn't able to write a test for that though.

The attributes "key_buffer", "myisam_recover" and "innodb_additional_mem_pool_size" led to errors when restarting mysql ("unknown variable 'key_buffer=16m'", etc.), so I renamed them to values I found in the documentation. I set "innodb_additional_mem_pool_size" to false, as you mentioned in the readme. I again checked that by checking the Ubuntu version and otherwise kept the old names. I wrote tests for that and also updated default_spec.rb to [require chefspec/berkshelf](https://github.com/sethvargo/chefspec#berkshelf).
