### PR TITLE
Update mariadb_repository.rb

### DIFF
--- a/recipes/mariadb_repository.rb
+++ b/recipes/mariadb_repository.rb
@@ -25,7 +25,7 @@ apt_repository 'mariadb' do
   distribution node['lsb']['codename']
   components %w(main)
   keyserver 'keyserver.ubuntu.com'
-  key '0xf1656f24c74cd1d8'
+  key '0xcbcb082a1bb943db'
 end
 
 # Prioritize MariaDB repository over system packages


### PR DESCRIPTION
GPG key is no longer correct which produces 

W: GPG error: http://ftp.hosteurope.de jessie InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY CBCB082A1BB943DB

mariadb.org gives another gpg key id:

https://downloads.mariadb.org/mariadb/repositories/#mirror=host-europe&version=10.1