### PR TITLE
Changed providers/password to use attribute pwd_col

### DIFF
--- a/attributes/defaults.rb
+++ b/attributes/defaults.rb
@@ -52,6 +52,11 @@ if node['mysqld']['use_mariadb']
 
   # This option is not present on mysql-5.7
   default['mysqld']['my.cnf']['mysqld_safe']['skip_log_error'] = true
+
+  # MariaDB and MySQL use different columns for user passwords
+  default['mysqld']['pwd_col'] = 'Password'
+else
+  default['mysqld']['pwd_col'] = 'authentication_string'
 end
 
 default['mysqld']['my.cnf']['mysqld']['user'] = 'mysql'

--- a/providers/password.rb
+++ b/providers/password.rb
@@ -21,7 +21,7 @@ require 'shellwords'
 
 action :set do
   r = execute "Assign mysql password for #{new_resource.user} user" do
-    query = "UPDATE user SET authentication_string = PASSWORD('#{Shellwords.escape(new_resource.password)}') WHERE User = '#{Shellwords.escape(new_resource.user)}'"
+    query = "UPDATE user SET #{node['mysqld']['pwd_col']} = PASSWORD('#{Shellwords.escape(new_resource.password)}') WHERE User = '#{Shellwords.escape(new_resource.user)}'"
     command %(mysql #{Shellwords.escape(new_resource.auth)} mysql -e "#{query}; FLUSH PRIVILEGES;")
     only_if %(mysql #{Shellwords.escape(new_resource.auth)} -e 'SHOW DATABASES;')
   end

--- a/spec/recipes/Berksfile.lock
+++ b/spec/recipes/Berksfile.lock
@@ -7,5 +7,5 @@ GRAPH
   apt (4.0.2)
     compat_resource (>= 12.10)
   compat_resource (12.14.6)
-  mysqld (2.0.0)
+  mysqld (2.1.0)
     apt (>= 0.0.0)

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -8,7 +8,9 @@ describe 'mysqld::default' do
   end
 
   let(:ubuntu_1604) do
-    ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe)
+    runner = ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04')
+    runner.node.override['mysqld']['use_mariadb'] = false
+    runner.converge(described_recipe)
   end
 
   it 'should use the correct mysql server package' do
@@ -37,5 +39,10 @@ describe 'mysqld::default' do
 
     expect(ubuntu_1604.node['mysqld']['my.cnf']['mysqld']['myisam-recover-options']).to eq('BACKUP')
     expect(debian.node['mysqld']['my.cnf']['mysqld']['myisam-recover-options']).to eq('BACKUP')
+  end
+
+  it 'should use the correct password column' do
+    expect(ubuntu_1604.node['mysqld']['pwd_col']).to eq('authentication_string')
+    expect(debian.node['mysqld']['pwd_col']).to eq('Password')
   end
 end


### PR DESCRIPTION
Since we now have an attribute that knows whether to install mariadb or mysql, it's possible to use another attribute to store which column should be used for the user password.
`Password`for mariadb
`authentication_string` for mysql

Should fix issue https://github.com/chr4-cookbooks/mysqld/issues/12