### PR TITLE
Add percona support, add kitchen and tests with serverspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,21 @@
-.bundle
+.vagrant
+# Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+/cookbooks
+
+# Bundler
+# Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml
+
+test/nodes
+
+Berksfile.lock

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,47 @@
+---
+driver:
+  name: vagrant
+  require_chef_omnibus: true
+
+platforms:
+  - name: ubuntu-16.04
+    driver_config:
+      box: bento/ubuntu-16.04
+  - name: debian-8
+    driver_config:
+      box: bento/debian-8.6
+
+suites:
+  - name: mariadb-10.1
+    run_list:
+      - recipe[mysqld::mariadb_repository]
+      - recipe[mysqld::default]
+    attributes:
+      mysqld:
+        db_install: 'mariadb'
+        root_password: 'abcdef01234567890'
+        repository:
+          mariadb:
+            version: '10.1'
+  - name: mariadb-10.2
+    run_list:
+      - recipe[mysqld::mariadb_repository]
+      - recipe[mysqld::default]
+    attributes:
+      mysqld:
+        db_install: 'mariadb'
+        root_password: 'abcdef01234567890'
+        repository:
+          mariadb:
+            version: '10.2'
+  - name: percona-5.7
+    run_list:
+      - recipe[mysqld::percona_repository]
+      - recipe[mysqld::default]
+    attributes:
+      mysqld:
+        db_install: 'percona'
+        root_password: 'abcdef01234567890'
+        repository:
+          percona:
+            version: '5.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ cache: bundler
 rvm:
 - 2.3.1
 script:
-- bundle exec rubocop
+- bundle exec cookstyle
 - cd spec/recipes && bundle exec rspec *.rb; cd -

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+source 'https://supermarket.chef.io'
+
+metadata

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'rubocop'
+gem 'cookstyle'
+gem 'foodcritic'
 gem 'rspec'
 gem 'chefspec'
 gem 'berkshelf'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     addressable (2.4.0)
     ast (2.3.0)
+    backports (3.6.8)
     berkshelf (5.1.0)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (>= 2.0.2, < 4.0)
@@ -37,10 +38,10 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef (12.14.89)
+    chef (12.15.19)
       addressable
       bundler (>= 1.10)
-      chef-config (= 12.14.89)
+      chef-config (= 12.15.19)
       chef-zero (>= 4.8)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -66,7 +67,7 @@ GEM
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef-config (12.14.89)
+    chef-config (12.15.19)
       addressable
       fuzzyurl
       mixlib-config (~> 2.0)
@@ -77,21 +78,35 @@ GEM
       mixlib-log (~> 1.3)
       rack (~> 2.0)
       uuidtools (~> 2.1)
-    chefspec (5.2.0)
+    chefspec (5.3.0)
       chef (>= 12.0)
       fauxhai (~> 3.6)
       rspec (~> 3.0)
     cleanroom (1.0.0)
+    cookstyle (0.0.1)
+      rubocop (= 0.39.0)
+    cucumber-core (2.0.0)
+      backports (~> 3.6)
+      gherkin (~> 4.0)
     diff-lcs (1.2.5)
     erubis (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    fauxhai (3.9.0)
+    fauxhai (3.10.0)
       net-ssh
     ffi (1.9.14)
     ffi-yajl (2.3.0)
       libyajl2 (~> 1.2)
+    foodcritic (8.1.0)
+      cucumber-core (>= 1.3)
+      erubis
+      nokogiri (>= 1.5, < 2.0)
+      rake
+      rufus-lru (~> 1.0)
+      treetop (~> 1.4)
+      yajl-ruby (~> 1.1)
     fuzzyurl (0.9.0)
+    gherkin (4.0.0)
     hashie (3.4.6)
     highline (1.7.8)
     hitimes (1.2.4)
@@ -100,6 +115,7 @@ GEM
     ipaddress (0.8.3)
     json (2.0.2)
     libyajl2 (1.2.0)
+    mini_portile2 (2.1.0)
     minitar (0.5.4)
     mixlib-archive (0.2.0)
       mixlib-log
@@ -109,7 +125,7 @@ GEM
     mixlib-config (2.2.4)
     mixlib-log (1.7.1)
     mixlib-shellout (2.2.7)
-    molinillo (0.5.1)
+    molinillo (0.5.3)
     multi_json (1.12.1)
     multipart-post (2.0.0)
     net-scp (1.2.1)
@@ -124,9 +140,11 @@ GEM
       net-ssh-gateway (>= 1.2.0)
     net-telnet (0.1.1)
     nio4r (1.2.1)
-    octokit (4.3.0)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
+    octokit (4.4.1)
       sawyer (~> 0.7.0, >= 0.5.3)
-    ohai (8.20.0)
+    ohai (8.21.0)
       chef-config (>= 12.5.0.alpha.1, < 13)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -141,10 +159,12 @@ GEM
     parser (2.3.1.4)
       ast (~> 2.2)
     plist (3.2.0)
+    polyglot (0.3.5)
     powerpack (0.1.1)
     proxifier (1.0.3)
     rack (2.0.1)
     rainbow (2.1.0)
+    rake (11.3.0)
     retryable (2.0.4)
     ridley (5.1.0)
       addressable
@@ -168,7 +188,7 @@ GEM
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
       rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.3)
+    rspec-core (3.5.4)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -183,27 +203,28 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (0.43.0)
-      parser (>= 2.3.1.1, < 3.0)
+    rubocop (0.39.0)
+      parser (>= 2.3.0.7, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
+    rufus-lru (1.1.0)
     sawyer (0.7.0)
       addressable (>= 2.3.5, < 2.5)
       faraday (~> 0.8, < 0.10)
     semverse (2.0.0)
-    serverspec (2.36.1)
+    serverspec (2.37.2)
       multi_json
       rspec (~> 3.0)
       rspec-its
       specinfra (~> 2.53)
-    sfl (2.2)
+    sfl (2.3)
     solve (3.0.1)
       molinillo (~> 0.4)
       semverse (>= 1.1, < 3.0)
-    specinfra (2.63.1)
+    specinfra (2.66.0)
       net-scp
       net-ssh (>= 2.7, < 4.0)
       net-telnet
@@ -213,12 +234,15 @@ GEM
     thor (0.19.1)
     timers (4.0.4)
       hitimes
+    treetop (1.6.8)
+      polyglot (~> 0.3)
     unicode-display_width (1.1.1)
     uuidtools (2.1.5)
     varia_model (0.6.0)
       buff-extensions (~> 2.0)
       hashie (>= 2.0.2, < 4.0.0)
     wmi-lite (1.0.0)
+    yajl-ruby (1.3.0)
 
 PLATFORMS
   ruby
@@ -226,8 +250,9 @@ PLATFORMS
 DEPENDENCIES
   berkshelf
   chefspec
+  cookstyle
+  foodcritic
   rspec
-  rubocop
 
 BUNDLED WITH
-   1.12.5
+   1.13.2

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ following attributes:
 ```ruby
 node['mysqld']['my.cnf_path']
 node['mysqld']['service_name']
-node['mysqld']['mysql_packages']          # When node['mysqld']['use_mariadb'] == false
-node['mysqld']['mariadb_packages']
-node['mysqld']['mariadb_galera_packages'] # When using mariadb_galera_install recipe
+node['mysqld']['mysql']['packages']
+node['mysqld']['mariadb']['packages']
+node['mysqld']['mariadb']['galera_packages'] # When using mariadb_galera_install recipe
 ```
 
 The configuration is stored in the ```node['mysqld']['my.cnf']``` hash, and can be adapted like so
@@ -88,6 +88,14 @@ node['mysqld']['root_password'] = 'yourpass'
 ```
 
 
+If you want to install percona/mysql instead of mariadb you can change the following attribute:
+
+```ruby
+node['mysqld']['db_install']
+```
+
+Valid values are `percona`, `mysql` or `mariadb`
+
 
 ## Recipes
 
@@ -105,8 +113,19 @@ Sets up official MariaDB repository to install packages from.
 Configure it using the following attributes
 
 ```ruby
-node['mysqld']['repository']['version'] # Defaults to '10.1'
-node['mysqld']['repository']['mirror']  # Defaults to HostEurope mirror
+node['mysqld']['repository']['mariadb']['version'] # Defaults to '10.1'
+node['mysqld']['repository']['mariadb']['mirror']  # Defaults to HostEurope mirror
+```
+
+### percona\_repository
+
+Sets up official Perconad repository to install packages from. This is called by default
+if you set `node['mysqld']['db_install']` to percona.
+Configure it using the following attributes
+
+```ruby
+node['mysqld']['repository']['percona']['version'] # Defaults to '5.7'
+node['mysqld']['repository']['percona']['mirror']  # Defaults to Percona Main Mirror.
 ```
 
 ### install

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,26 @@
+#!/usr/bin/env rake
+
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:unit) do |t|
+  t.pattern = ['test/unit/**/*_spec.rb']
+end
+
+require 'foodcritic'
+FoodCritic::Rake::LintTask.new do |t|
+  t.options = { fail_tags: ['any'] }
+end
+
+require 'cookstyle'
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new do |task|
+  task.options << '--display-cop-names'
+end
+
+begin
+  require 'kitchen/rake_tasks'
+  Kitchen::RakeTasks.new
+rescue LoadError
+  puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
+end
+
+task default: [:foodcritic, :rubocop]

--- a/attributes/defaults.rb
+++ b/attributes/defaults.rb
@@ -18,17 +18,23 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-# Attribute that defines whether MariaDB or MySQL should be used
-default['mysqld']['use_mariadb'] = true
+# Attribute that defines whether MariaDB, MySQL or Percona should be used
+default['mysqld']['db_install'] = 'mariadb'
 
 # Default packages to install
-default['mysqld']['mysql_packages'] = %w(mysql-server)
-default['mysqld']['mariadb_packages'] = %w(mariadb-server)
-default['mysqld']['mariadb_galera_packages'] = %w(mariadb-galera-server)
+default['mysqld']['mysql']['packages'] = %w(mysql-server)
+default['mysqld']['mariadb']['packages'] = %w(mariadb-server)
+default['mysqld']['mariadb']['galera_packages'] = %w(mariadb-galera-server)
 
 # MariaDB repository configuration
-default['mysqld']['repository']['version'] = '10.1'
-default['mysqld']['repository']['mirror'] = 'http://ftp.hosteurope.de/mirror/mariadb.org/repo'
+default['mysqld']['repository']['mariadb']['version'] = '10.1'
+default['mysqld']['repository']['mariadb']['mirror'] = 'http://ftp.hosteurope.de/mirror/mariadb.org/repo'
+
+# Percona repository configuration
+default['mysqld']['repository']['percona']['version'] = '5.7'
+default['mysqld']['repository']['percona']['mirror'] = 'http://repo.percona.com/apt'
+
+default['mysqld']['percona']['packages'] = %w(percona-server-server-5.7)
 
 # Configure services
 default['mysqld']['my.cnf_path'] = '/etc/mysql/my.cnf'
@@ -42,7 +48,7 @@ default['mysqld']['root_password'] = nil
 default['mysqld']['auth'] = '--defaults-file=/etc/mysql/debian.cnf'
 
 # Options, only set by default/ available on MariaDB
-if node['mysqld']['use_mariadb']
+if node['mysqld']['db_install'] == 'mariadb'
   # Charset options are only set on MariaDB by default
   default['mysqld']['my.cnf']['client']['default-character-set'] = 'utf8mb4'
   default['mysqld']['my.cnf']['mysql']['default-character-set'] = 'utf8mb4'
@@ -53,6 +59,14 @@ if node['mysqld']['use_mariadb']
   # This option is not present on mysql-5.7
   default['mysqld']['my.cnf']['mysqld_safe']['skip_log_error'] = true
 end
+
+# Password columns for user passwords
+default['mysqld']['pwd_col'] = case node['mysqld']['db_install']
+                               when 'mariadb'
+                                 'Password'
+                               else
+                                 'authentication_string'
+                               end
 
 default['mysqld']['my.cnf']['mysqld']['user'] = 'mysql'
 default['mysqld']['my.cnf']['mysqld']['port'] = 3306

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,4 +5,7 @@ license          'GNU Public License 3.0'
 description      'Installs/Configures mysqld'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.1.0'
+issues_url       'https://github.com/chr4-cookbooks/mysqld/issues'
+source_url       'https://github.com/chr4-cookbooks/mysqld/'
+
 depends          'apt'

--- a/providers/password.rb
+++ b/providers/password.rb
@@ -21,7 +21,7 @@ require 'shellwords'
 
 action :set do
   r = execute "Assign mysql password for #{new_resource.user} user" do
-    query = "UPDATE user SET authentication_string = PASSWORD('#{Shellwords.escape(new_resource.password)}') WHERE User = '#{Shellwords.escape(new_resource.user)}'"
+    query = "UPDATE user SET #{Shellwords.escape(node['mysqld']['pwd_col'])} = PASSWORD('#{Shellwords.escape(new_resource.password)}') WHERE User = '#{Shellwords.escape(new_resource.user)}'"
     command %(mysql #{Shellwords.escape(new_resource.auth)} mysql -e "#{query}; FLUSH PRIVILEGES;")
     only_if %(mysql #{Shellwords.escape(new_resource.auth)} -e 'SHOW DATABASES;')
   end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -18,9 +18,18 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+# This way we force to have updated indexes
+include_recipe 'apt'
+
 # Install packages
-if node['mysqld']['use_mariadb']
-  Array(node['mysqld']['mariadb_packages']).each { |pkg| package pkg }
+case node['mysqld']['db_install']
+when 'mariadb'
+  Array(node['mysqld']['mariadb']['packages']).each { |pkg| package pkg }
+when 'percona'
+  # Always use the official percona repository, as some distributions
+  # use percona-5.6, and the default attributes of this cookbook require 5.7
+  include_recipe 'mysqld::percona_repository'
+  Array(node['mysqld']['percona']['packages']).each { |pkg| package pkg }
 else
-  Array(node['mysqld']['mysql_packages']).each { |pkg| package pkg }
+  Array(node['mysqld']['mysql']['packages']).each { |pkg| package pkg }
 end

--- a/recipes/mariadb_repository.rb
+++ b/recipes/mariadb_repository.rb
@@ -21,12 +21,10 @@
 require 'uri'
 
 apt_repository 'mariadb' do
-  uri "#{node['mysqld']['repository']['mirror']}/#{node['mysqld']['repository']['version']}/#{node['platform']}"
+  uri "#{node['mysqld']['repository']['mariadb']['mirror']}/#{node['mysqld']['repository']['mariadb']['version']}/#{node['platform']}"
   distribution node['lsb']['codename']
   components %w(main)
   keyserver 'keyserver.ubuntu.com'
-
-  # Since Ubuntu xenial, the repository uses a new key
   if node['platform_version'].to_f < 16.04
     key '0xcbcb082a1bb943db'
   else
@@ -39,7 +37,7 @@ file '/etc/apt/preferences.d/mariadb.pref' do
   mode 0o644
   content <<-EOS
     Package: *
-    Pin: origin #{URI.parse(node['mysqld']['repository']['mirror']).host}
+    Pin: origin #{URI.parse(node['mysqld']['repository']['mariadb']['mirror']).host}
     Pin-Priority: 1000
   EOS
 end

--- a/recipes/percona_repository.rb
+++ b/recipes/percona_repository.rb
@@ -1,8 +1,9 @@
 #
 # Cookbook Name:: mysqld
-# Recipe:: mariadb_galera_install
+# Recipe:: percona_repository
 #
 # Copyright 2014, Chris Aumann
+# Copyright 2016, Adrian Almenar
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,5 +19,20 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-# Install MariaDB + Galera packages
-Array(node['mysqld']['mariadb']['galera_packages']).each { |pkg| package pkg }
+apt_repository 'percona' do
+  uri node['mysqld']['repository']['percona']['mirror']
+  distribution node['lsb']['codename']
+  components %w(main)
+  keyserver 'keyserver.ubuntu.com'
+  key '8507EFA5'
+end
+
+# Prioritize Percona repository over system packages
+file '/etc/apt/preferences.d/percona.pref' do
+  mode 0o644
+  content <<-EOS
+    Package: *
+    Pin: release o=Percona Development Team
+    Pin-Priority: 1001
+  EOS
+end

--- a/spec/recipes/Berksfile.lock
+++ b/spec/recipes/Berksfile.lock
@@ -7,5 +7,5 @@ GRAPH
   apt (4.0.2)
     compat_resource (>= 12.10)
   compat_resource (12.14.6)
-  mysqld (2.0.0)
+  mysqld (2.1.0)
     apt (>= 0.0.0)

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -8,12 +8,14 @@ describe 'mysqld::default' do
   end
 
   let(:ubuntu_1604) do
-    ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe)
+    runner = ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04')
+    runner.node.override['mysqld']['db_install'] = 'mysql'
+    runner.converge(described_recipe)
   end
 
   it 'should use the correct mysql server package' do
-    expect(debian.node['mysqld']['mysql_packages']).to eq(%w(mysql-server))
-    expect(ubuntu_1604.node['mysqld']['mysql_packages']).to eq(%w(mysql-server))
+    expect(debian.node['mysqld']['mysql']['packages']).to eq(%w(mysql-server))
+    expect(ubuntu_1604.node['mysqld']['mysql']['packages']).to eq(%w(mysql-server))
   end
 
   it 'should use distribution specific my.cnf path' do
@@ -37,5 +39,10 @@ describe 'mysqld::default' do
 
     expect(ubuntu_1604.node['mysqld']['my.cnf']['mysqld']['myisam-recover-options']).to eq('BACKUP')
     expect(debian.node['mysqld']['my.cnf']['mysqld']['myisam-recover-options']).to eq('BACKUP')
+  end
+
+  it 'should use the correct password column' do
+    expect(ubuntu_1604.node['mysqld']['pwd_col']).to eq('authentication_string')
+    expect(debian.node['mysqld']['pwd_col']).to eq('Password')
   end
 end

--- a/test/integration/mariadb-10.1/serverspec/mariadb-10.1_spec.rb
+++ b/test/integration/mariadb-10.1/serverspec/mariadb-10.1_spec.rb
@@ -1,0 +1,23 @@
+require 'serverspec'
+require 'pathname'
+
+set :backend, :exec
+
+describe service('mysql') do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe port(3306) do
+  it { should be_listening }
+end
+
+describe command('mysql -uroot -pabcdef01234567890 -N -s -r -e \'select version();\'') do
+  its(:stdout) { should match '^10\.1\.' }
+  its(:stdout) { should match 'MariaDB' }
+end
+
+describe command('mysql -udebian-sys-maint -pabcdef01234567890 -N -s -r -e \'select version();\'') do
+  its(:stdout) { should match '^10\.1\.' }
+  its(:stdout) { should match 'MariaDB' }
+end

--- a/test/integration/mariadb-10.2/serverspec/mariadb-10.2_spec.rb
+++ b/test/integration/mariadb-10.2/serverspec/mariadb-10.2_spec.rb
@@ -1,0 +1,23 @@
+require 'serverspec'
+require 'pathname'
+
+set :backend, :exec
+
+describe service('mysql') do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe port(3306) do
+  it { should be_listening }
+end
+
+describe command('mysql -uroot -pabcdef01234567890 -N -s -r -e \'select version();\'') do
+  its(:stdout) { should match '^10\.2\.' }
+  its(:stdout) { should match 'MariaDB' }
+end
+
+describe command('mysql -udebian-sys-maint -pabcdef01234567890 -N -s -r -e \'select version();\'') do
+  its(:stdout) { should match '^10\.2\.' }
+  its(:stdout) { should match 'MariaDB' }
+end

--- a/test/integration/percona-5.7/serverspec/percona-5.7_spec.rb
+++ b/test/integration/percona-5.7/serverspec/percona-5.7_spec.rb
@@ -1,0 +1,17 @@
+require 'serverspec'
+require 'pathname'
+
+set :backend, :exec
+
+describe service('mysql') do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe port(3306) do
+  it { should be_listening }
+end
+
+describe command('mysql -uroot -pabcdef01234567890 -N -s -r -e \'select version();\'') do
+  its(:stdout) { should match '^5\.7\.' }
+end


### PR DESCRIPTION
Add percona support, add kitchen and tests with serverspec and integrate pull request chr4-cookbooks/mysqld/pull/13 with some changes to include percona and versions of databases.